### PR TITLE
margin, padding fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ The source code contains a more detailed documentation.
 
 ### Container
 
-Urwid offers no way to directly get the position of a widget,  
-so that's why positions are calculated relative to this widget  
+Positions are calculated relative to this widget  
 which means that urwid_ueberzogen.Container has to be the root widget  
 in order to calculate the absolute position.  
 


### PR DESCRIPTION
A new method to calculate the position of the image widgets as the old one fails to take e.g. paddings into account.  
(Urwid doesn't seems to store the padding information in the children attribute of a canvas)  
